### PR TITLE
Update fugue-aws-cloudtrail-integration.yml

### DIFF
--- a/aws-cloudtrail/fugue-aws-cloudtrail-integration.yml
+++ b/aws-cloudtrail/fugue-aws-cloudtrail-integration.yml
@@ -27,7 +27,6 @@ Resources:
     Type: AWS::Events::Rule
     Properties:
       Description: Fugue Events Rule
-      RoleArn: !GetAtt FugueEventsRole.Arn
       EventPattern:
         source:
           - "aws.acm"
@@ -87,3 +86,4 @@ Resources:
       Targets:
         - Arn: !Ref EventBusArn
           Id: "TargetEventBus"
+          RoleArn: !GetAtt FugueEventsRole.Arn


### PR DESCRIPTION
AWS made an update to Cloudformation templates- the `RoleArn: !GetAtt FugueEventsRole.Arn` needs to be at the end